### PR TITLE
extract charset manually to be able to handle naming differences

### DIFF
--- a/src/main/java/co/cfly/email/impl/util/MailUtility.java
+++ b/src/main/java/co/cfly/email/impl/util/MailUtility.java
@@ -49,7 +49,7 @@ import jakarta.mail.internet.ParseException;
 public class MailUtility {
 
     public static final String DOMAIN_PROPERTY_KEY = "co.cfly.email.domainName";
-    public static final Pattern CHARSET_EXTRACT = Pattern.compile("charset=(.+?)($|;)", Pattern.CASE_INSENSITIVE);
+    public static final Pattern CHARSET_EXTRACT = Pattern.compile("charset\\s*=\\s*\"?([^\";]*)\"?", Pattern.CASE_INSENSITIVE);
 
     public static InternetAddress internetAddress(String address) throws InvalidAddressException {
         try {
@@ -292,19 +292,18 @@ public class MailUtility {
      * Determines the content type of the part, or empty if it cannot determine
      */
     public static Optional<Charset> determineCharset(Part part) throws MessagingException {
-        Optional<String> contentTypeValue = Arrays.stream(part.getHeader("Content-Type")).findFirst();
-        if (contentTypeValue.isPresent()) {
-            final String value = contentTypeValue.get();
+        return Arrays.stream(part.getHeader("Content-Type")).findFirst().map(value -> {
             Matcher matcher = CHARSET_EXTRACT.matcher(value);
             if (matcher.find()) {
-                return Optional.of(Charset.forName(matcher.group(1).trim()));
+                String charsetName = matcher.group(1).trim().toUpperCase();
+                return switch (charsetName) {
+                    case "CP-850" -> Charset.forName("CP850");
+                    default -> Charset.forName(charsetName);
+                };
             }
             else {
-                return Optional.empty();
+                return null;
             }
-        }
-        else {
-            return Optional.empty();
-        }
+        });
     }
 }

--- a/src/main/java/co/cfly/email/impl/util/MailUtility.java
+++ b/src/main/java/co/cfly/email/impl/util/MailUtility.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -291,7 +290,7 @@ public class MailUtility {
     /**
      * Determines the content type of the part, or empty if it cannot determine
      */
-    public static Optional<Charset> determineCharset(Part part) throws MessagingException {
+    public static Charset determineCharset(Part part, Charset defaultValue) throws MessagingException {
         return Arrays.stream(part.getHeader("Content-Type")).findFirst().map(value -> {
             Matcher matcher = CHARSET_EXTRACT.matcher(value);
             if (matcher.find()) {
@@ -304,6 +303,6 @@ public class MailUtility {
             else {
                 return null;
             }
-        });
+        }).orElse(defaultValue);
     }
 }

--- a/src/main/java/co/cfly/email/impl/util/MessageConverter.java
+++ b/src/main/java/co/cfly/email/impl/util/MessageConverter.java
@@ -162,7 +162,7 @@ public class MessageConverter {
 
     private String convertBodyPart(Part part) throws MessagingException, UnsupportedEncodingException {
         try {
-            return new String(part.getInputStream().readAllBytes(), MailUtility.determineCharset(part).orElse(StandardCharsets.UTF_8));
+            return new String(part.getInputStream().readAllBytes(), MailUtility.determineCharset(part, StandardCharsets.UTF_8));
         }
         catch (UnsupportedEncodingException e) {
             throw e;

--- a/src/main/java/co/cfly/email/impl/util/MessageConverter.java
+++ b/src/main/java/co/cfly/email/impl/util/MessageConverter.java
@@ -162,12 +162,7 @@ public class MessageConverter {
 
     private String convertBodyPart(Part part) throws MessagingException, UnsupportedEncodingException {
         try {
-            if (part.getContent() instanceof String value) {
-                return value;
-            }
-            else {
-                return new String(part.getInputStream().readAllBytes(), MailUtility.determineCharset(part).orElse(StandardCharsets.UTF_8));
-            }
+            return new String(part.getInputStream().readAllBytes(), MailUtility.determineCharset(part).orElse(StandardCharsets.UTF_8));
         }
         catch (UnsupportedEncodingException e) {
             throw e;

--- a/src/test/java/co/cfly/email/MailUtilityTest.java
+++ b/src/test/java/co/cfly/email/MailUtilityTest.java
@@ -29,21 +29,21 @@ public class MailUtilityTest {
     public void determineCharset() throws MessagingException {
         MimeBodyPart part = new MimeBodyPart();
         part.addHeader("Content-Type", "text/plain;charset=utf-8; Content-Transfer-Encoding:base64");
-        Assert.assertEquals(StandardCharsets.UTF_8, MailUtility.determineCharset(part).orElseThrow(RuntimeException::new));
+        Assert.assertEquals(StandardCharsets.UTF_8, MailUtility.determineCharset(part, StandardCharsets.UTF_8));
     }
 
     @Test
     public void determineCharsetQuoted() throws MessagingException {
         MimeBodyPart part = new MimeBodyPart();
         part.addHeader("Content-Type", "text/plain;charset=\"utf-8\"; Content-Transfer-Encoding:base64");
-        Assert.assertEquals(StandardCharsets.UTF_8, MailUtility.determineCharset(part).orElseThrow(RuntimeException::new));
+        Assert.assertEquals(StandardCharsets.UTF_8, MailUtility.determineCharset(part, StandardCharsets.UTF_8));
     }
 
     @Test
     public void determineCharsetNoSemiColon() throws MessagingException {
         MimeBodyPart part = new MimeBodyPart();
         part.addHeader("Content-Type", "text/plain;charset=utf-8");
-        Assert.assertEquals(StandardCharsets.UTF_8, MailUtility.determineCharset(part).orElseThrow(RuntimeException::new));
+        Assert.assertEquals(StandardCharsets.UTF_8, MailUtility.determineCharset(part, StandardCharsets.UTF_8));
     }
 
     @Test

--- a/src/test/java/co/cfly/email/MailUtilityTest.java
+++ b/src/test/java/co/cfly/email/MailUtilityTest.java
@@ -33,6 +33,13 @@ public class MailUtilityTest {
     }
 
     @Test
+    public void determineCharsetQuoted() throws MessagingException {
+        MimeBodyPart part = new MimeBodyPart();
+        part.addHeader("Content-Type", "text/plain;charset=\"utf-8\"; Content-Transfer-Encoding:base64");
+        Assert.assertEquals(StandardCharsets.UTF_8, MailUtility.determineCharset(part).orElseThrow(RuntimeException::new));
+    }
+
+    @Test
     public void determineCharsetNoSemiColon() throws MessagingException {
         MimeBodyPart part = new MimeBodyPart();
         part.addHeader("Content-Type", "text/plain;charset=utf-8");


### PR DESCRIPTION
for example we occassionally get a email with the charset as CP-850 when java only recognizes CP850